### PR TITLE
Add TypeScript definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,46 @@
+export default class SelectorObserver {
+  constructor(rootNode: Node)
+  disconnect(): void
+  observe: typeof observe
+}
+
+export declare function observe<T extends Element>(
+  selector: string,
+  options: {
+    constructor: {new (): T}
+  } & Options<T>
+): Observer
+export declare function observe<T extends Element>(
+  options: {
+    selector: string
+    constructor: {new (): T}
+  } & Options<T>
+): Observer
+export declare function observe(selector: string, initialize: InitializerCallback<Element>): Observer
+export declare function observe(selector: string, options: Options<Element>): Observer
+export declare function observe(options: {selector: string} & Options<Element>): Observer
+
+type Options<T> = {
+  initialize?: InitializerCallback<T>
+  add?: AddCallback<T>
+  remove?: RemoveCallback<T>
+  subscribe?: SubscribeCallback<T>
+}
+
+type InitializerCallback<T> = (el: T) => void | InitializerCallbacks<T>
+type AddCallback<T> = (el: T) => void
+type RemoveCallback<T> = (el: T) => void
+type SubscribeCallback<T> = (el: T) => Subscription
+
+type InitializerCallbacks<T> = {
+  add?: AddCallback<T>
+  remove?: RemoveCallback<T>
+}
+
+type Observer = {
+  abort(): void
+}
+
+interface Subscription {
+  unsubscribe(): void
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Allows you to monitor DOM elements that match a CSS selector",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "types": "dist/index.esm.d.ts",
   "scripts": {
     "test": "npm run build-test && npm run flow && npm run lint && npm run karma",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint .",
     "flow": "flow check",
     "karma": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
-    "build-umd": "rollup -c rollup.config.umd.js && cp lib/index.js.flow dist/index.umd.js.flow",
-    "build-esm": "rollup -c rollup.config.esm.js && cp lib/index.js.flow dist/index.esm.js.flow",
+    "build-umd": "rollup -c rollup.config.umd.js && cp lib/index.js.flow dist/index.umd.js.flow && cp lib/index.d.ts dist/index.umd.d.ts",
+    "build-esm": "rollup -c rollup.config.esm.js && cp lib/index.js.flow dist/index.esm.js.flow && cp lib/index.d.ts dist/index.esm.d.ts",
     "build-test": "rollup -c rollup.config.test.js",
     "build": "npm run build-umd && npm run build-esm",
     "prepack": "npm run build"
@@ -26,8 +26,10 @@
   },
   "homepage": "https://github.com/josh/selector-observer#readme",
   "files": [
+    "dist/index.esm.d.ts",
     "dist/index.esm.js.flow",
     "dist/index.esm.js",
+    "dist/index.umd.d.ts",
     "dist/index.umd.js.flow",
     "dist/index.umd.js"
   ],


### PR DESCRIPTION
Adding TypeScript definitions, in addition to Flow types.

Things I've learned:

* Flow and TypeScript definitions use a pretty similar format. For the most part I could copy over Flow definitions and start from there.
* TypeScript uses a different syntax for generic type constraints `Options<T extends Element>` (ts) vs `Options<T: Element>`(flow)
* Flow has `Class<T>` where TS will prefer matching the class-ish interface `{new (): T}`
* TypeScript objects are sealed by default where Flow has `{ }` and `{| |}`.
* TypeScript function overloading feature is great. Flow must use intersection types and it easily gets confused picking the correct function signature without explicit annotation.

View [TypeScript definitions](https://github.com/josh/selector-observer/blob/typescript/lib/index.d.ts) vs current [Flow definitions](https://github.com/josh/selector-observer/blob/typescript/lib/index.js.flow).

Closes #11.

##

CC: @dgraham @mislav @muan @keithamus @koddsson @joshaber