### PR TITLE
Allow all observe methods to receive generics

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -16,9 +16,9 @@ export declare function observe<T extends Element>(
     constructor: {new (): T}
   } & Options<T>
 ): Observer
-export declare function observe(selector: string, initialize: InitializerCallback<Element>): Observer
-export declare function observe(selector: string, options: Options<Element>): Observer
-export declare function observe(options: {selector: string} & Options<Element>): Observer
+export declare function observe<T extends Element>(selector: string, initialize: InitializerCallback<T>): Observer
+export declare function observe<T extends Element>(selector: string, options: Options<T>): Observer
+export declare function observe<T extends Element>(options: {selector: string} & Options<T>): Observer
 
 type Options<T> = {
   initialize?: InitializerCallback<T>


### PR DESCRIPTION
`observe` allows for semi generics by supplying the [constructor](https://github.com/josh/selector-observer#constructor-matching) keyword in the options bag. This change adds generics to the other `observe` method signatures allowing consuming libraries to supply generics directly without needing to supply a `constructor` option.